### PR TITLE
Fix migrateMappings using wrong yarn group

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,9 @@ dependencies {
     implementation ('com.google.code.gson:gson:2.10.1')
     implementation ('com.google.guava:guava:31.1-jre')
 
-    compileOnly("net.fabricmc:fabric-loom:" + baseVersion + "-SNAPSHOT")
+    implementation ("net.fabricmc:fabric-loom:" + baseVersion + "-SNAPSHOT")
+    // needed for 'validatePlugins' task, same version as used by fabric-loom
+    compileOnly ("net.fabricmc:mapping-io:0.2.1")
 }
 
 jar {

--- a/src/main/java/net/legacyfabric/legacylooming/LegacyLoomingGradlePlugin.java
+++ b/src/main/java/net/legacyfabric/legacylooming/LegacyLoomingGradlePlugin.java
@@ -7,6 +7,7 @@ import net.fabricmc.loom.task.AbstractRemapJarTask;
 import net.fabricmc.loom.util.ZipUtils;
 import net.legacyfabric.legacylooming.providers.LWJGL2LibraryProcessor;
 import net.legacyfabric.legacylooming.providers.LegacyFabricIntermediaryMappingsProvider;
+import net.legacyfabric.legacylooming.tasks.MigrateLegacyMappingsTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.PluginAware;
@@ -23,8 +24,6 @@ public class LegacyLoomingGradlePlugin implements Plugin<PluginAware> {
     public static final String VERSION = Objects.requireNonNullElse(LegacyLoomingGradlePlugin.class.getPackage().getImplementationVersion(), "0.0.0+unknown");
 
     private Project project;
-
-
 
     @Override
     public void apply(PluginAware target) {
@@ -85,6 +84,11 @@ public class LegacyLoomingGradlePlugin implements Plugin<PluginAware> {
                     });
                 }
             });
+
+            // override loom's migrateMappings to fix issues
+            var migrateTask = project.getTasks().replace("migrateMappings", MigrateLegacyMappingsTask.class);
+            migrateTask.setDescription("Migrates mappings to a new version.");
+            migrateTask.getOutputs().upToDateWhen(o -> false);
         }
     }
 }

--- a/src/main/java/net/legacyfabric/legacylooming/tasks/MigrateLegacyMappingsTask.java
+++ b/src/main/java/net/legacyfabric/legacylooming/tasks/MigrateLegacyMappingsTask.java
@@ -4,55 +4,69 @@ import net.fabricmc.loom.configuration.DependencyInfo;
 import net.fabricmc.loom.task.MigrateMappingsTask;
 import net.fabricmc.loom.util.Constants;
 import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.work.DisableCachingByDefault;
 
 @DisableCachingByDefault(because = "Always rerun this tasks.")
 public abstract class MigrateLegacyMappingsTask extends MigrateMappingsTask {
-    private String mappings;
+    private Logger logger;
+    private String targetMappings;
 
     @Override
     @Option(option = "mappings", description = "Target mappings")
     public void setMappings(String mappings) {
         super.setMappings(mappings);
-        this.mappings = mappings;
+        this.targetMappings = mappings;
     }
 
     @Override
     @TaskAction
     public void doTask() throws Throwable {
         Project project = getProject();
+        logger = project.getLogger();
 
-        DependencyInfo minecraftDep = DependencyInfo.create(project, Constants.Configurations.MINECRAFT);
-        String minecraftDepString = minecraftDep.getDepString();
-        String minecraftVersion = minecraftDepString.substring(minecraftDepString.lastIndexOf(':') + 1);
+        try {
+            DependencyInfo minecraftDep = DependencyInfo.create(project, Constants.Configurations.MINECRAFT);
+            String minecraftDepString = minecraftDep.getDepString();
+            String minecraftVersion = minecraftDepString.substring(minecraftDepString.lastIndexOf(':') + 1);
 
-        DependencyInfo mappingsDep = DependencyInfo.create(project, Constants.Configurations.MAPPINGS);
-        String mappingsDepString = mappingsDep.getDepString();
+            DependencyInfo mappingsDep = DependencyInfo.create(project, Constants.Configurations.MAPPINGS);
+            String mappingsDepString = mappingsDep.getDepString();
 
-        this.checkForLegacyYarn(project, mappingsDepString, minecraftVersion);
+            this.checkForLegacyYarn(mappingsDepString, minecraftVersion);
+        } catch (Exception e) {
+            logger.warn("Failed to check if legacyfabric yarn mappings are used!", e);
+        }
 
         super.doTask();
     }
 
-    private void checkForLegacyYarn(Project project, String mappingsDepString, String minecraftVersion) {
+    private void checkForLegacyYarn(String mappingsDepString, String minecraftVersion) {
         if (mappingsDepString.startsWith("net.legacyfabric:yarn")) {
-            project.getLogger().info("Detected legacyfabric yarn mappings, adjusting target mappings");
-
-            String yarnBuild;
-            if (mappings.matches("^[0-9.]+\\+build\\.[0-9]+$")) {
-                yarnBuild = mappings;
-            }
-            else if (mappings.matches("^[0-9]+$")) {
-                yarnBuild = minecraftVersion + "+build." + mappings;
-            }
-            else {
-                project.getLogger().info("The provided target mappings aren't a yarn build, skipping");
-                return;
-            }
-
-            setMappings("net.legacyfabric:yarn:" + yarnBuild + ":v2");
+            logger.info("Detected legacyfabric yarn mappings, adjusting target mappings");
+            this.adjustTargetMappings("net.legacyfabric:yarn", minecraftVersion);
         }
+        else if (mappingsDepString.startsWith("net.legacyfabric.v2:yarn")) {
+            logger.info("Detected legacyfabric yarn v2 mappings, adjusting target mappings");
+            this.adjustTargetMappings("net.legacyfabric.v2:yarn", minecraftVersion);
+        }
+    }
+
+    private void adjustTargetMappings(String yarnPath, String minecraftVersion) {
+        String yarnBuild;
+        if (targetMappings.matches("^[0-9.]+\\+build\\.[0-9]+$")) {
+            yarnBuild = targetMappings;
+        }
+        else if (targetMappings.matches("^[0-9]+$")) {
+            yarnBuild = minecraftVersion + "+build." + targetMappings;
+        }
+        else {
+            logger.info("The provided target mappings aren't a yarn build, skipping");
+            return;
+        }
+
+        this.setMappings(yarnPath + ":" + yarnBuild + ":v2");
     }
 }

--- a/src/main/java/net/legacyfabric/legacylooming/tasks/MigrateLegacyMappingsTask.java
+++ b/src/main/java/net/legacyfabric/legacylooming/tasks/MigrateLegacyMappingsTask.java
@@ -1,0 +1,58 @@
+package net.legacyfabric.legacylooming.tasks;
+
+import net.fabricmc.loom.configuration.DependencyInfo;
+import net.fabricmc.loom.task.MigrateMappingsTask;
+import net.fabricmc.loom.util.Constants;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+import org.gradle.work.DisableCachingByDefault;
+
+@DisableCachingByDefault(because = "Always rerun this tasks.")
+public abstract class MigrateLegacyMappingsTask extends MigrateMappingsTask {
+    private String mappings;
+
+    @Override
+    @Option(option = "mappings", description = "Target mappings")
+    public void setMappings(String mappings) {
+        super.setMappings(mappings);
+        this.mappings = mappings;
+    }
+
+    @Override
+    @TaskAction
+    public void doTask() throws Throwable {
+        Project project = getProject();
+
+        DependencyInfo minecraftDep = DependencyInfo.create(project, Constants.Configurations.MINECRAFT);
+        String minecraftDepString = minecraftDep.getDepString();
+        String minecraftVersion = minecraftDepString.substring(minecraftDepString.lastIndexOf(':') + 1);
+
+        DependencyInfo mappingsDep = DependencyInfo.create(project, Constants.Configurations.MAPPINGS);
+        String mappingsDepString = mappingsDep.getDepString();
+
+        this.checkForLegacyYarn(project, mappingsDepString, minecraftVersion);
+
+        super.doTask();
+    }
+
+    private void checkForLegacyYarn(Project project, String mappingsDepString, String minecraftVersion) {
+        if (mappingsDepString.startsWith("net.legacyfabric:yarn")) {
+            project.getLogger().info("Detected legacyfabric yarn mappings, adjusting target mappings");
+
+            String yarnBuild;
+            if (mappings.matches("^[0-9.]+\\+build\\.[0-9]+$")) {
+                yarnBuild = mappings;
+            }
+            else if (mappings.matches("^[0-9]+$")) {
+                yarnBuild = minecraftVersion + "+build." + mappings;
+            }
+            else {
+                project.getLogger().info("The provided target mappings aren't a yarn build, skipping");
+                return;
+            }
+
+            setMappings("net.legacyfabric:yarn:" + yarnBuild + ":v2");
+        }
+    }
+}


### PR DESCRIPTION
This replaces/extends the migrateMappings task to change the yarn group before the task executes.

With this migrateMappings can be used in the following ways:
```sh
gradlew migrateMappings --mappings "529"
gradlew migrateMappings --mappings "1.12.2+build.529"
gradlew migrateMappings --mappings "net.legacyfabric:yarn:1.12.2+build.529:v2"
```